### PR TITLE
Cherry-picked, modified commit 2815be1 adding peer metrics

### DIFF
--- a/pkg/gobgp_exporter/describe.go
+++ b/pkg/gobgp_exporter/describe.go
@@ -58,4 +58,7 @@ func (n *RouterNode) Describe(ch chan<- *prometheus.Desc) {
 	ch <- bgpPeerRemovePrivateAsFlag
 	ch <- bgpPeerPasswodSetFlag
 	ch <- bgpPeerType
+	ch <- bgpPeerAfiSafiStateAccepted
+	ch <- bgpPeerAfiSafiStateAdvertised
+	ch <- bgpPeerAfiSafiStateReceived
 }

--- a/pkg/gobgp_exporter/describe_peer.go
+++ b/pkg/gobgp_exporter/describe_peer.go
@@ -161,4 +161,25 @@ var (
 		"PeerState.PeerType",
 		[]string{"name"}, nil,
 	)
+	bgpPeerAfiSafiStateReceived = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "peer", "received_prefix_count"),
+		"AfiState.Received",
+		[]string{"name", "address_family"}, nil,
+	)
+	bgpPeerAfiSafiStateAccepted = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "peer", "accepted_prefix_count"),
+		"AfiState.Accepted",
+		[]string{"name", "address_family"}, nil,
+	)
+	bgpPeerAfiSafiStateAdvertised = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "peer", "advertised_prefix_count"),
+		"Afistate.Advertised",
+		[]string{"name", "address_family"}, nil,
+	)
+
+	bgpPeerInfo = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "peer", "info"),
+		"Information about the bgp peer",
+		[]string{"name", "description", "peer_as", "import_policy", "export_policy"}, nil,
+	)
 )


### PR DESCRIPTION
Before the Tomasz's PR was merged (here: https://github.com/tobymitico/gobgp_exporter/commit/290db54350d6f2e66d8d4ada70456e1420e31396) we used gobgp-v3.12 branch, as the most forward branch. It had the last common commit with main at a25118d. 
After Tomasz's merge with upstream commits that also updated gobgp to v3.23, it skipped 2815be17bf7daeae290f73b49152d8befd6a0094 commit, which added additional peers and we started using main branch as the most forward branch. This PR is a cherry-pick of that commit with resolved imports, so the final state is gobgp_exporter using the newest gobgp v3.27.1-0.20240607131100-7d2d020bd226, has all upstream changes and also missing metrics, that were there before.
 
![image](https://github.com/tobymitico/gobgp_exporter/assets/82508914/25317448-85a4-4324-a016-f37c68dd505f)

Tested just by checking if the missing metrics are there. 